### PR TITLE
chore: rename to keeli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# i18n-validator [![CI](https://github.com/radiovisual/i18n-validator/actions/workflows/ci.yml/badge.svg)](https://github.com/radiovisual/i18n-validator/actions/workflows/ci.yml) [![codecov](https://codecov.io/github/radiovisual/i18n-validator/graph/badge.svg?token=G4X3X08FB6)](https://codecov.io/github/radiovisual/i18n-validator)
+# keeli [![CI](https://github.com/radiovisual/keeli/actions/workflows/ci.yml/badge.svg)](https://github.com/radiovisual/keeli/actions/workflows/ci.yml) [![codecov](https://codecov.io/github/radiovisual/keeli/graph/badge.svg?token=G4X3X08FB6)](https://codecov.io/github/radiovisual/keeli)
 
 > Configurable CLI validation tool to look for common problems in your translated source files.
 
 ## Why?
 
-> Have you ever shipped "buggy" translation files to your users in production? **Probably!**. I know I have!
+> Have you ever shipped "buggy" translation files to your users in production? **Probably!** I know I have!
 
 Translated files in your software project are an often-overlooked source of problems that can affect the usability, reliability and reputation of your applications. These translated files are often edited manually, built automatically (without any integrity checks) or outsourced to third parties to provide translations. These files typically do not pass through any (or most) of your automated tests, or they get skipped in your manual tests...which means the hidden problems get shipped to your real users in production.
 
@@ -12,11 +12,11 @@ Furthermore, there are best practices we want to adhere to with our translated f
 
 ## Roadmap to Version `1.0.0`
 
-We are getting close to the initial `1.0.0` release. :tada: Check out [this milestone](https://github.com/radiovisual/i18n-validator/milestone/1) for details.
+We are getting close to the initial `1.0.0` release. :tada: Check out [this milestone](https://github.com/radiovisual/keeli/milestone/1) for details.
 
 ## Configuration
 
-For each project where you want to run the i18n-validator, you will need to have a file named `i18n-validator.config.json` with the following format:
+For each project where you want to run the keeli, you will need to have a file named `keeli.config.json` with the following format:
 
 ```json5
 {
@@ -84,7 +84,7 @@ For each project where you want to run the i18n-validator, you will need to have
 	 **/
 	dryRun: false,
 	/**
-	 * Enable or disable this entire i18n-validator.
+	 * Enable or disable this entire keeli.
 	 *
 	 **/
 	enabled: true,
@@ -148,6 +148,10 @@ One of the main motivations with this CLI is to _expose_ (not hide) the problems
 # Contributing
 
 Contributions to this project are always welcome! :heart: Feel free to open issues, pull requests, etc and let's make this project better together.
+
+If you have the repo cloned locally, you can test run the CLI by running:
+
+`run build && node dist/index.js`, which will run all of the validation rules on the translation files in the fixtures directory. If you have the CLI linked with npm then you can just run `npm run build && keeli`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "i18n-validator",
+	"name": "keeli",
 	"version": "0.0.1",
 	"main": "dist/index.js",
 	"description": "Configurable CLI validation tool to check for common problems in your translated source files.",
@@ -9,7 +9,7 @@
 		"url": "https://github.com/radiovisual"
 	},
 	"bugs": {
-		"url": "https://github.com/radiovisual/i18n-validator/issues"
+		"url": "https://github.com/radiovisual/keeli/issues"
 	},
 	"scripts": {
 		"build:prod": "rm -rf dist/* && node build/cli.mjs",

--- a/src/classes/logger.class.ts
+++ b/src/classes/logger.class.ts
@@ -18,7 +18,7 @@ class Logger {
 			problemStore.getIgnoredValidationProblems();
 	}
 
-	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/i18n-validator/issues/3
+	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/keeli/issues/3
 	public logErrors() {
 		this.problemStore.getAllProblems().forEach((problem) => {
 			console.log(`${problem.severity} | ${problem.locale} ${problem.message}`);
@@ -27,7 +27,7 @@ class Logger {
 		console.log(this.getPrintSummary());
 	}
 
-	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/i18n-validator/issues/3
+	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/keeli/issues/3
 	public getPrintSummary() {
 		let summary = ["\n"];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { config } from "./config/default-config.ts";
 
 const defaultConfig: Config = config;
 
-const configPath = path.join(__dirname, "../i18n-validator.config.json");
+const configPath = path.join(__dirname, "../keeli.config.json");
 
 // Only start the routine running if the configuration file is found.
 if (fs.existsSync(configPath)) {
@@ -21,14 +21,14 @@ if (fs.existsSync(configPath)) {
 	const config = { ...defaultConfig, ...userConfig };
 
 	if (!config.enabled) {
-		const message = `i18n-validator is disabled. Exiting.`;
+		const message = `keeli is disabled. Exiting.`;
 		console.log(chalk.yellow(message));
 		process.exit(1);
 	}
 
 	runRules(config);
 } else {
-	const message = `You must have an i18n-validator.config.js file in the project root to run the i18n-validator.`;
+	const message = `You must have an keeli.config.js file in the project root to run the keeli.`;
 	console.log(chalk.red(message));
 	process.exit(1);
 }

--- a/src/rules/no-empty-messages/README.md
+++ b/src/rules/no-empty-messages/README.md
@@ -76,4 +76,4 @@ To disable the check for this rule for specific keys, you can pass in the name o
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/rules/no-html-messages/README.md
+++ b/src/rules/no-html-messages/README.md
@@ -88,4 +88,4 @@ To disable the check for this rule for specific keys, you can pass in the name o
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/rules/no-invalid-configuration/README.md
+++ b/src/rules/no-invalid-configuration/README.md
@@ -38,4 +38,4 @@ This rule is not configurable, i.e., you can't assign a severity level or turn t
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/rules/no-invalid-variables/README.md
+++ b/src/rules/no-invalid-variables/README.md
@@ -103,4 +103,4 @@ To disable the check for this rule for specific keys, you can pass in the name o
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/rules/no-missing-keys/README.md
+++ b/src/rules/no-missing-keys/README.md
@@ -41,4 +41,4 @@ This rule does not support any advanced configuration.
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/rules/no-untranslated-messages/README.md
+++ b/src/rules/no-untranslated-messages/README.md
@@ -73,4 +73,4 @@ To disable the check for this rule for specific keys, you can pass in the name o
 
 ## Version
 
-This rule was introduced in i18n-validator v1.0.0.
+This rule was introduced in keeli v1.0.0.

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -30,7 +30,7 @@ export function loadLanguageFiles(config: Config): TranslationFiles {
 		);
 
 		try {
-			// TODO: convert to JSON before parsing if the file is not JSON. https://github.com/radiovisual/i18n-validator/issues/2
+			// TODO: convert to JSON before parsing if the file is not JSON. https://github.com/radiovisual/keeli/issues/2
 			files[locale] = JSON.parse(fs.readFileSync(translatedFilePath, "utf8"));
 		} catch (err: unknown) {
 			console.error(


### PR DESCRIPTION
Renames the module from `i18n-validator` to `keeli`