### PR TITLE
feat: add pretty-printed logs. Closes #3

### DIFF
--- a/keeli.config.json
+++ b/keeli.config.json
@@ -9,10 +9,13 @@
 	"rules": {
 		"no-untranslated-messages": "error",
 		"no-empty-messages": "error",
-		"no-extra-whitespace": "error",
-		"no-html-messages": "error",
+		"no-extra-whitespace": {
+			"severity": "error",
+			"ignoreKeys": []
+		},
+		"no-html-messages": "kjh",
 		"no-missing-keys": "error",
-		"no-invalid-variables": "error",
+		"no-invalid-variables": "warn",
 		"no-malformed-keys": {
 			"severity": "error",
 			"namingConvention": "kebab-case"

--- a/keeli.config.json
+++ b/keeli.config.json
@@ -13,9 +13,9 @@
 			"severity": "error",
 			"ignoreKeys": []
 		},
-		"no-html-messages": "kjh",
+		"no-html-messages": "error",
 		"no-missing-keys": "error",
-		"no-invalid-variables": "warn",
+		"no-invalid-variables": "error",
 		"no-malformed-keys": {
 			"severity": "error",
 			"namingConvention": "kebab-case"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@formatjs/icu-messageformat-parser": "^2.7.8",
 		"chalk": "^4.0.0",
+		"cli-table3": "^0.6.5",
 		"flattie": "^1.1.1",
 		"lodash": "^4.17.21"
 	},

--- a/src/classes/logger.class.ts
+++ b/src/classes/logger.class.ts
@@ -1,67 +1,175 @@
 import { ProblemStore } from "./problem-store.class.ts";
 import { Problem } from "./problem.class.ts";
+import Table, {
+	HorizontalTableRow,
+	VerticalTableRow,
+	CrossTableRow,
+	Cell,
+} from "cli-table3";
+import chalk from "chalk";
+import { SEVERITY_LEVEL } from "../constants.ts";
 
 class Logger {
 	private problemStore: ProblemStore;
-	private validationProblems: Problem[];
+	private validationProblems: { [locale: string]: Problem[] };
 	private configurationProblems: Problem[];
-	private ignoredConfigurationProblems: Problem[];
-	private ignoredValidationProblems: Problem[];
+	private isDryRun: boolean;
 
-	public constructor(problemStore: ProblemStore) {
+	public constructor(problemStore: ProblemStore, isDryRun: boolean) {
 		this.problemStore = problemStore;
 		this.validationProblems = problemStore.getValidationProblems();
 		this.configurationProblems = problemStore.getConfigurationProblems();
-		this.ignoredConfigurationProblems =
-			problemStore.getIgnoredConfigurationProblems();
-		this.ignoredValidationProblems =
-			problemStore.getIgnoredValidationProblems();
+		this.isDryRun = isDryRun;
 	}
 
-	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/keeli/issues/3
 	public logErrors() {
-		this.problemStore.getAllProblems().forEach((problem) => {
-			console.log(
-				`${problem.severity} | ${problem?.locale ?? ""} ${problem.message}`
-			);
+		Object.entries(this.validationProblems).forEach(
+			([locale, problemArray]) => {
+				const problemTable = this.getNewTable();
+				console.log(`\n\nProblems found in locale: ${chalk.cyan(locale)}`);
+				problemArray.forEach((problem) => {
+					problemTable.push(this.getTableRow(problem));
+				});
+				console.log(problemTable.toString());
+			}
+		);
+
+		const configTable = this.getNewTable();
+		this.configurationProblems.forEach((problem) => {
+			configTable.push(this.getTableRow(problem));
 		});
-		console.log("---");
+
+		if (this.configurationProblems.length > 0) {
+			console.log(`\n\nProblems found in ${chalk.cyan("configuration")}`);
+			console.log(configTable.toString());
+		}
+
 		console.log(this.getPrintSummary());
+
+		if (this.isDryRun) {
+			console.log(
+				chalk.cyan(`\n\ndryRun is enabled for keeli. Errors will not throw.`)
+			);
+		}
 	}
 
-	// TODO: Clean up this summary when the pretty reporter is done https://github.com/radiovisual/keeli/issues/3
+	public getTableRow(problem: Problem): Array<Cell> {
+		const {
+			severity,
+			isIgnored,
+			ruleMeta,
+			locale,
+			message,
+			expected,
+			received,
+		} = problem;
+
+		let items: Array<
+			string | HorizontalTableRow | VerticalTableRow | CrossTableRow | Cell
+		> = [];
+		let colSpan = 0;
+
+		if (severity === SEVERITY_LEVEL.error) {
+			if (isIgnored) {
+				items.push(chalk.red.strikethrough("error"));
+			} else {
+				items.push(chalk.red("error"));
+			}
+		} else if (severity === SEVERITY_LEVEL.warn) {
+			if (isIgnored) {
+				items.push(chalk.yellow.strikethrough("warn"));
+			} else {
+				items.push(chalk.yellow("warn"));
+			}
+		}
+
+		if (locale) {
+			items.push(chalk.dim(locale));
+			colSpan++;
+		}
+
+		let messageWitDiff = isIgnored
+			? `${chalk.yellow("[ignored]")} ${message}`
+			: message;
+
+		if (expected || received) {
+			messageWitDiff += "\n\n";
+		}
+
+		if (expected) {
+			messageWitDiff += `${chalk.cyan("Expected")}: ${expected}\n`;
+		}
+
+		if (received) {
+			messageWitDiff += `${chalk.magenta("Received")}: ${received}\n`;
+		}
+
+		items.push(messageWitDiff);
+		items.push(ruleMeta.name);
+
+		return items as Cell[];
+	}
+
+	public getNewTable(useBorders = true) {
+		if (useBorders) {
+			return new Table();
+		}
+
+		return new Table({
+			chars: {
+				top: "",
+				"top-mid": "",
+				"top-left": "",
+				"top-right": "",
+				bottom: "",
+				"bottom-mid": "",
+				"bottom-left": "",
+				"bottom-right": "",
+				left: "",
+				"left-mid": "",
+				mid: "",
+				"mid-mid": "",
+				right: "",
+				"right-mid": "",
+				middle: " ",
+			},
+			style: { "padding-left": 0, "padding-right": 0 },
+		});
+	}
+
 	public getPrintSummary() {
-		let summary = ["\n"];
+		const summaryTable = this.getNewTable(false);
 
-		summary.push(`Error(s) found: ${this.problemStore.getErrorCount()}`);
+		const ignoredErrorCount = this.problemStore.getIgnoredErrorCount();
+		const errorCount = this.problemStore.getErrorCount() + ignoredErrorCount;
 
-		if (this.problemStore.getIgnoredConfigurationProblemsCount() > 0) {
-			summary.push(
-				`Ignored Configuration Errors(s): ${this.problemStore.getIgnoredConfigurationProblemsCount()}`
+		const ignoredWarningCount = this.problemStore.getIgnoredWarningCount();
+		const warningCount =
+			this.problemStore.getWarningCount() + ignoredWarningCount;
+
+		const errorSummary = [chalk.red("Errors:"), chalk.red(errorCount)];
+
+		if (ignoredErrorCount > 0) {
+			errorSummary.push(
+				`${chalk.dim.italic("(" + ignoredErrorCount + " ignored)")}`
 			);
 		}
 
-		if (this.problemStore.getIgnoredValidationProblemsCount() > 0) {
-			summary.push(
-				`Ignored Validation Errors(s): ${this.problemStore.getIgnoredValidationProblemsCount()}`
+		const warningSummary = [
+			chalk.yellow("Warnings:"),
+			chalk.yellow(warningCount),
+		];
+
+		if (ignoredWarningCount > 0) {
+			warningSummary.push(
+				`${chalk.dim.italic("(" + ignoredWarningCount + " ignored)")}`
 			);
 		}
 
-		if (this.problemStore.getIgnoredErrorCount() > 0) {
-			summary.push(
-				`Ignored Errors: ${this.problemStore.getIgnoredErrorCount()}`
-			);
-		}
+		summaryTable.push(errorSummary);
+		summaryTable.push(warningSummary);
 
-		summary.push(`Warnings(s) found: ${this.problemStore.getWarningCount()}`);
-
-		if (this.problemStore.getIgnoredWarningCount() > 0) {
-			summary.push(
-				`Ignored Warnings: ${this.problemStore.getIgnoredWarningCount()}`
-			);
-		}
-
-		return summary.join("\n");
+		return `\n\n${summaryTable.toString()}`;
 	}
 }
 

--- a/src/engine/rule-engine.ts
+++ b/src/engine/rule-engine.ts
@@ -30,7 +30,7 @@ function runRules(config: Config) {
 		});
 	});
 
-	if (problemStore.getConfigurationProblemCount() > 0) {
+	if (problemStore.getConfigurationErrorCount() > 0) {
 		exitRun(problemStore, config.dryRun);
 		return;
 	}
@@ -51,11 +51,11 @@ function runRules(config: Config) {
 }
 
 function exitRun(problemStore: ProblemStore, isDryRun: boolean) {
-	const problems = problemStore.getProblems();
+	const errorCount = problemStore.getErrorCount();
 
-	const hasErrors = problems.length > 0;
+	const hasErrors = errorCount > 0;
 
-	const logger = new Logger(problemStore);
+	const logger = new Logger(problemStore, isDryRun);
 
 	logger.logErrors();
 

--- a/src/rules/no-invalid-severity/problems.ts
+++ b/src/rules/no-invalid-severity/problems.ts
@@ -19,8 +19,8 @@ export function getInvalidSeverityProblem(
 	return Problem.Builder.withRuleMeta(ruleMeta)
 		.withSeverity(severity)
 		.withMessage(
-			`Invalid severity: "${invalidSeverity}" assigned to ${ruleName}. You must use: ${validSeverities.join(
-				"|"
+			`Invalid severity: "${invalidSeverity}" assigned to ${ruleName}. Use: ${validSeverities.join(
+				" | "
 			)}`
 		)
 		.build();

--- a/src/utils/rules-helpers.ts
+++ b/src/utils/rules-helpers.ts
@@ -1,3 +1,4 @@
+import { validSeverities } from "../constants";
 import type { Config, Rule, RuleSeverity } from "../types";
 
 /**
@@ -9,13 +10,14 @@ import type { Config, Rule, RuleSeverity } from "../types";
 export function getRuleSeverity(config: Config, rule: Rule): RuleSeverity {
 	const ruleConfig = config.rules[rule.meta.name];
 
-	if (typeof ruleConfig === "string") {
+	if (typeof ruleConfig === "string" && validSeverities.includes(ruleConfig)) {
 		return ruleConfig;
 	}
 
 	if (
 		typeof ruleConfig === "object" &&
-		typeof ruleConfig?.severity === "string"
+		typeof ruleConfig?.severity === "string" &&
+		validSeverities.includes(ruleConfig.severity)
 	) {
 		return ruleConfig.severity;
 	}


### PR DESCRIPTION

    - [x] Errors are grouped by filename (locale)
    - [x] Adds color highlighting
    - [x] Uses a table for nice spacing
    - [x] Expected | received diffs are shown in the logs
    - [x] The rule name prints
    - [x] Ignored errors are indicated
    - [x] the final print summary should be cleaned up with good information (how many ignored, etc)
