### PR TITLE
ci: fix publishing latest dist-tag for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show diff for debugging
-        run: git diff
+      - name: Show package.json and package-lock.json changes
+        run: |
+          cat package.json
+          cat package-lock.json
+          git diff
 
       # Create a Pull Request with the version bump if the release is not a pre-release
       - name: Create Pull Request for Version Bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,24 @@ jobs:
       - run: npm ci
       - name: Extract version from tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Check for pre-release
+        id: check_pre_release
+        run: |
+          if [[ "${{ env.RELEASE_VERSION }}" == *-* ]]; then
+            echo "IS_PRE_RELEASE=true" >> $GITHUB_ENV
+            echo "RELEASE_TAG=next" >> $GITHUB_ENV
+          else
+            echo "IS_PRE_RELEASE=false" >> $GITHUB_ENV
+            echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+          fi
       - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version
       - run: npm run build
-      - run: npm publish
+      - name: Publish to npm
+        run: npm publish --tag ${{ env.RELEASE_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Commit and push version bump
+        if: env.IS_PRE_RELEASE == 'false'
         run: |
           git checkout -b version-bump/${{ env.RELEASE_VERSION }}
           git add package.json
@@ -31,9 +43,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # This step will only run if all previous steps have succeeded
+      # This step will only run if all previous steps have succeeded and if it's not a pre-release
       - name: Create Pull Request for Version Bump
-        if: success()
+        if: success() && env.IS_PRE_RELEASE == 'false'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Update package version to ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         if: env.IS_PRE_RELEASE == 'false'
         run: |
           git checkout -b version-bump/${{ env.RELEASE_VERSION }}
-          git add package.json
+          git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ env.RELEASE_VERSION }}"
           git push origin version-bump/${{ env.RELEASE_VERSION }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             echo "IS_PRE_RELEASE=false" >> $GITHUB_ENV
             echo "RELEASE_TAG=latest" >> $GITHUB_ENV
           fi
-      - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version
+      - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version --no-commit
       - run: npm run build
       - name: Publish to npm
         run: npm publish --tag ${{ env.RELEASE_TAG }}
@@ -42,12 +42,6 @@ jobs:
           git push origin version-bump/${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Show package.json and package-lock.json changes
-        run: |
-          cat package.json
-          cat package-lock.json
-          git diff
 
       # Create a Pull Request with the version bump if the release is not a pre-release
       - name: Create Pull Request for Version Bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,10 @@ jobs:
           git push origin version-bump/${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Create a Pull Request with the version bump if the release is not a pre-release
       - name: Create Pull Request for Version Bump
         if: success() && env.IS_PRE_RELEASE == 'false'
+        id: create_pull_request
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Update package version to ${{ env.RELEASE_VERSION }}
@@ -53,8 +55,7 @@ jobs:
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
-
-      # Automatically enable auto-merge on the created PR with the version bump
+      # Auto-merge the Pull Request with the version bump if the release is not a pre-release
       - name: Enable Auto-Merge
         if: success() && env.IS_PRE_RELEASE == 'false'
         uses: peter-evans/enable-pull-request-automerge@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
           git push origin version-bump/${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # This step will only run if all previous steps have succeeded and if it's not a pre-release
       - name: Create Pull Request for Version Bump
         if: success() && env.IS_PRE_RELEASE == 'false'
         uses: peter-evans/create-pull-request@v6
@@ -55,3 +53,12 @@ jobs:
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
+
+      # Automatically enable auto-merge on the created PR with the version bump
+      - name: Enable Auto-Merge
+        if: success() && env.IS_PRE_RELEASE == 'false'
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
+# Permissions set for the GITHUB_TOKEN (these might also be set on the GitHub Account)
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,7 +50,7 @@ jobs:
       - name: Create Pull Request for Version Bump
         if: success() && env.IS_PRE_RELEASE == 'false'
         id: create_pull_request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: Update package version to ${{ env.RELEASE_VERSION }}
           title: "chore: update package version to ${{ env.RELEASE_VERSION }}"
@@ -59,14 +62,14 @@ jobs:
 
       # Auto-merge the Pull Request with the version bump if the release is not a pre-release
       - name: Enable Auto-Merge
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        uses: peter-evans/enable-pull-request-automerge@v2
+        if: success() && env.IS_PRE_RELEASE == 'false' && steps.create_pull_request.outputs.pull-request-number
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
           pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
 
-        # Clean up the version bump branch after merge
+      # Clean up the version bump branch after merge
       - name: Delete Version Bump Branch
         if: success() && env.IS_PRE_RELEASE == 'false'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,3 @@ jobs:
         run: npm publish --tag ${{ env.RELEASE_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Commit and push version bump
-        if: env.IS_PRE_RELEASE == 'false'
-        run: |
-          git checkout -b version-bump/${{ env.RELEASE_VERSION }}
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to ${{ env.RELEASE_VERSION }}"
-          git push origin version-bump/${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
-# Permissions set for the GITHUB_TOKEN (these might also be set on the GitHub Account)
-permissions:
-  contents: write
-  pull-requests: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -63,7 +59,7 @@ jobs:
 
       # Auto-merge the Pull Request with the version bump if the release is not a pre-release
       - name: Enable Auto-Merge
-        if: success() && env.IS_PRE_RELEASE == 'false' && steps.create_pull_request.outputs.pull-request-number
+        if: success() && env.IS_PRE_RELEASE == 'false'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,20 +56,3 @@ jobs:
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
-
-      # Auto-merge the Pull Request with the version bump if the release is not a pre-release
-      - name: Enable Auto-Merge
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          merge-method: squash
-
-      # Clean up the version bump branch after merge
-      - name: Delete Version Bump Branch
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        run: |
-          git push origin --delete version-bump/${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             echo "IS_PRE_RELEASE=false" >> $GITHUB_ENV
             echo "RELEASE_TAG=latest" >> $GITHUB_ENV
           fi
-      - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version --no-commit
+      - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version
       - run: npm run build
       - name: Publish to npm
         run: npm publish --tag ${{ env.RELEASE_TAG }}
@@ -40,36 +40,5 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ env.RELEASE_VERSION }}"
           git push origin version-bump/${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Create a Pull Request with the version bump if the release is not a pre-release
-      - name: Create Pull Request for Version Bump
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        id: create_pull_request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: Update package version to ${{ env.RELEASE_VERSION }}
-          title: "chore: update package version to ${{ env.RELEASE_VERSION }}"
-          body: "Updates `package.json` version to `${{ env.RELEASE_VERSION }}`."
-          branch: version-bump/${{ env.RELEASE_VERSION }}
-          labels: version-bump
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: main
-
-      # Auto-merge the Pull Request with the version bump if the release is not a pre-release
-      - name: Enable Auto-Merge
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          merge-method: squash
-
-      # Clean up the version bump branch after merge
-      - name: Delete Version Bump Branch
-        if: success() && env.IS_PRE_RELEASE == 'false'
-        run: |
-          git push origin --delete version-bump/${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           git push origin version-bump/${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Create a Pull Request with the version bump if the release is not a pre-release
       - name: Create Pull Request for Version Bump
         if: success() && env.IS_PRE_RELEASE == 'false'
@@ -55,6 +56,7 @@ jobs:
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
+
       # Auto-merge the Pull Request with the version bump if the release is not a pre-release
       - name: Enable Auto-Merge
         if: success() && env.IS_PRE_RELEASE == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Show diff for debugging
+        run: git diff
+
       # Create a Pull Request with the version bump if the release is not a pre-release
       - name: Create Pull Request for Version Bump
         if: success() && env.IS_PRE_RELEASE == 'false'
@@ -56,3 +59,20 @@ jobs:
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
+
+      # Auto-merge the Pull Request with the version bump if the release is not a pre-release
+      - name: Enable Auto-Merge
+        if: success() && env.IS_PRE_RELEASE == 'false'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+
+      # Clean up the version bump branch after merge
+      - name: Delete Version Bump Branch
+        if: success() && env.IS_PRE_RELEASE == 'false'
+        run: |
+          git push origin --delete version-bump/${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,11 @@ jobs:
           pull-request-number: ${{ steps.create_pull_request.outputs.pull-request-number }}
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+
+        # Clean up the version bump branch after merge
+      - name: Delete Version Bump Branch
+        if: success() && env.IS_PRE_RELEASE == 'false'
+        run: |
+          git push origin --delete version-bump/${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ If you have the repo cloned locally, you can test run the CLI by running:
 
 # Publishing
 
-Create a GitHub release with the version number you want to create. Make sure the tag you create matches the version number (e.g., `v1.2.3`) and release! GitHub actions will take over and attempt to publish the package version you specified. Note that a Pull request will get opened on the repo automatically to bump the package version to align with the latest release. This PR should be merged ASAP after opened to keep things in sync.
+Create a GitHub release with the version number you want to create. Make sure the tag you create matches the version number (e.g., `v1.2.3`) and release! GitHub actions will take over and attempt to publish the package version you specified.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Furthermore, there are best practices we want to adhere to with our translated f
 
 Keeli will help you automatically discover many problems with your translation files, including:
 
-✅ Finds untranslated messages
-✅ Finds empty messages
-✅ Finds missing variables
-✅ Finds accidentally translated variables
-✅ Finds variable syntax errors
-✅ Finds missing keys
-✅ Finds unknown/un-balanced keys
-✅ Finds keys violating your naming convention
-✅ Finds extra whitespace
-✅ Finds HTML in messages
-✅ _...and more!_
+- ✅ Finds untranslated messages
+- ✅ Finds empty messages
+- ✅ Finds missing variables
+- ✅ Finds accidentally translated variables
+- ✅ Finds variable syntax errors
+- ✅ Finds missing keys
+- ✅ Finds unknown/un-balanced keys
+- ✅ Finds keys violating your naming convention
+- ✅ Finds extra whitespace
+- ✅ Finds HTML in messages
+- ✅ _...and more!_
 
 Most of these rules are configurable so you can customize keeli to your specific needs.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "keeli",
-	"version": "0.0.1",
+	"version": "0.0.0",
 	"main": "dist/index.js",
 	"description": "Configurable CLI validation tool to check for common problems in your translated source files.",
 	"author": {


### PR DESCRIPTION
- Adds a script that checks if the PR is a pre-release. If yes, it wont publish using the latest dist-tag
- Adds a condition to auto-merge the PR created with the version bump
- Version bump PRs are not opened for pre-release version numbers